### PR TITLE
require ability to edit menus before displaying form

### DIFF
--- a/app/helpers/effective_menus_helper.rb
+++ b/app/helpers/effective_menus_helper.rb
@@ -3,7 +3,7 @@ module EffectiveMenusHelper
     menu = Effective::Menu.find_by_title(menu) if menu.kind_of?(String)
     return "<ul class='nav navbar-nav'><li>Menu '#{menu}' does not exist</li></ul>".html_safe if !menu.present?
 
-    if (effectively_editting? && EffectivePages.authorized?(:edit, Effective::Menu) rescue false)
+    if (effectively_editting? && EffectivePages.authorized?(:edit, menu) rescue false)
       options[:menu_id] = menu.id
       form_for(menu, :url => '/') { |form| options[:form] = form }
     end

--- a/app/helpers/effective_menus_helper.rb
+++ b/app/helpers/effective_menus_helper.rb
@@ -3,7 +3,7 @@ module EffectiveMenusHelper
     menu = Effective::Menu.find_by_title(menu) if menu.kind_of?(String)
     return "<ul class='nav navbar-nav'><li>Menu '#{menu}' does not exist</li></ul>".html_safe if !menu.present?
 
-    if (effectively_editting? rescue false)
+    if (effectively_editting? && EffectivePages.authorized?(:edit, Effective::Menu) rescue false)
       options[:menu_id] = menu.id
       form_for(menu, :url => '/') { |form| options[:form] = form }
     end


### PR DESCRIPTION
In a project, a chapter admin should be able to edit a chapter page but not edit site-wide content. The chapter admin should not be able to edit the navigation menu but effective_pages is currently allowing it. Here, I check for authorization before displaying the edit form of the Effective::Menu.