### PR TITLE
Add new window checkbox to carousel links

### DIFF
--- a/app/datatables/effective_carousel_items_datatable.rb
+++ b/app/datatables/effective_carousel_items_datatable.rb
@@ -17,6 +17,7 @@ class EffectiveCarouselItemsDatatable < Effective::Datatable
 
     col :link_label, visible: false
     col :link_url, visible: false
+    col :new_window, label: 'New window', visible: false
     col :caption, visible: false
 
     actions_col

--- a/app/models/effective/carousel_item.rb
+++ b/app/models/effective/carousel_item.rb
@@ -23,6 +23,7 @@ module Effective
 
       link_label        :string
       link_url          :string
+      new_window        :boolean
 
       position          :integer
 

--- a/app/views/admin/carousel_items/_form_carousel_item.html.haml
+++ b/app/views/admin/carousel_items/_form_carousel_item.html.haml
@@ -15,6 +15,8 @@
     .col= f.text_field :link_label
     .col= f.url_field :link_url
 
+  = f.check_box :new_window, label: 'Open link in a new window'
+
   = f.file_field :file, label: 'Image attachment', hint: EffectivePages.carousels_hint_text
   = f.text_field :caption, hint: 'Optional'
 

--- a/app/views/effective/carousels/_carousel.html.haml
+++ b/app/views/effective/carousels/_carousel.html.haml
@@ -11,12 +11,22 @@
       .carousel-inner
         - carousel_items.each_with_index do |item, index|
           .carousel-item{class: ('active' if index == 0)}
-            - if item.caption.blank?
-            = image_tag(item.file, class: 'd-block w-100', alt: "Slide #{index+1}")
+            - if item.link_url.present?
+              - link_options = item.new_window? ? { target: '_blank' } : {}
+              = link_to item.link_url, **link_options do
+                - if item.caption.blank?
+                  = image_tag(item.file, class: 'd-block w-100', alt: "Slide #{index+1}")
+                - else
+                  = image_tag(item.file, alt: item.caption)
+                  .carousel-caption.d-none.d-md-block
+                    %p= item.caption
             - else
-              = image_tag(item.file, alt: item.caption)
-              .carousel-caption.d-none.d-md-block
-                %p= item.caption
+              - if item.caption.blank?
+                = image_tag(item.file, class: 'd-block w-100', alt: "Slide #{index+1}")
+              - else
+                = image_tag(item.file, alt: item.caption)
+                .carousel-caption.d-none.d-md-block
+                  %p= item.caption
 
       %button.carousel-control-prev{'data-target': '#' + uid, type: 'button', 'data-slide': 'prev'}
         %span.carousel-control-prev-icon{'aria-hidden': true}

--- a/app/views/effective/carousels/_carousel.html.haml
+++ b/app/views/effective/carousels/_carousel.html.haml
@@ -11,22 +11,21 @@
       .carousel-inner
         - carousel_items.each_with_index do |item, index|
           .carousel-item{class: ('active' if index == 0)}
-            - if item.link_url.present?
-              - link_options = item.new_window? ? { target: '_blank' } : {}
+            - link_options = item.new_window? ? { target: '_blank' } : {}
+            - if item.link_url.present? && item.caption.present?
               = link_to item.link_url, **link_options do
-                - if item.caption.blank?
-                  = image_tag(item.file, class: 'd-block w-100', alt: "Slide #{index+1}")
-                - else
-                  = image_tag(item.file, alt: item.caption)
-                  .carousel-caption.d-none.d-md-block
-                    %p= item.caption
-            - else
-              - if item.caption.blank?
-                = image_tag(item.file, class: 'd-block w-100', alt: "Slide #{index+1}")
-              - else
                 = image_tag(item.file, alt: item.caption)
                 .carousel-caption.d-none.d-md-block
                   %p= item.caption
+            - elsif item.link_url.present?
+              = link_to item.link_url, **link_options do
+                = image_tag(item.file, class: 'd-block w-100', alt: "Slide #{index+1}")
+            - elsif item.caption.present?
+              = image_tag(item.file, alt: item.caption)
+              .carousel-caption.d-none.d-md-block
+                %p= item.caption
+            - else
+              = image_tag(item.file, class: 'd-block w-100', alt: "Slide #{index+1}")
 
       %button.carousel-control-prev{'data-target': '#' + uid, type: 'button', 'data-slide': 'prev'}
         %span.carousel-control-prev-icon{'aria-hidden': true}

--- a/db/migrate/101_create_effective_pages.rb
+++ b/db/migrate/101_create_effective_pages.rb
@@ -87,6 +87,7 @@ class CreateEffectivePages < ActiveRecord::Migration[6.0]
 
       t.string :link_label
       t.string :link_url
+      t.boolean :new_window, default: false
 
       t.integer :position
 


### PR DESCRIPTION
## Summary
- Adds a `new_window` boolean column to `carousel_items`
- Admin form exposes an "Open link in a new window" checkbox
- Admin datatable shows a "New window" column (hidden by default)

## Test plan
- [ ] Run migrations
- [ ] Create/edit a carousel item and toggle the new window checkbox
- [ ] Confirm the column appears in the admin datatable when toggled visible
- [ ] Confirm consumers can read `carousel_item.new_window?` to render `target="_blank"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)